### PR TITLE
Allow for pinned variables in pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,24 @@ def handle_info({:hello, name}, state) do
 end
 ```
 
+### Using local variables
+
+Sometimes one wish to subscribe using a pattern involving local variables.
+The `subscribe` macro accepts a `bind_quoted` argument, that will replace pinned variables with the given values.
+
+E.g.
+
+```elixir
+size = 42
+Hub.subscribe("my channel", %{size: ^size}, bind_quoted: [size: size])
+```
+
+is equivalent to
+
+```elixir
+Hub.subscribe("my channel", %{size: 42})
+```
+
 ## Examples
 
 Subscribe only once to a message:

--- a/test/hub_test.exs
+++ b/test/hub_test.exs
@@ -124,4 +124,12 @@ defmodule HubTest do
     result = Task.await(task)
     assert result == ~w(Me You)
   end
+
+  test "local variables parts of pattern" do
+    name = "World"
+    Hub.subscribe("global", {:hello, ^name}, bind_quoted: [name: name])
+    Hub.publish("global", {:hello, "World"})
+
+    assert_received({:hello, "World"})
+  end
 end


### PR DESCRIPTION
Can now make a subscription with a pinned variable:

```elixir
size = 42
Hub.subscribe("my channel", %{size: ^size}, bind_quoted: [size: size])
```