### PR TITLE
Can subscribe to multiple patterns in one subscription

### DIFF
--- a/test/hub_test.exs
+++ b/test/hub_test.exs
@@ -156,4 +156,26 @@ defmodule HubTest do
       Hub.publish("global", "message")
     end
   end
+
+  test "subscribe with multiple patterns" do
+    Hub.subscribe("global", [{:hello, name}, {:goodbye, name}], multi: true)
+    Hub.publish("global", {:hello, "World"})
+    Hub.publish("global", {:goodbye, "World"})
+
+    assert_received({:hello, "World"})
+    assert_received({:goodbye, "World"})
+  end
+
+  test "subscribe with multiple patterns and count 1" do
+    Hub.subscribe("global", [{:hello, name}, {:goodbye, name}], multi: true, count: 1)
+    Hub.publish("global", {:hello, "World"})
+    Hub.publish("global", {:goodbye, "World"})
+    assert_received({:hello, "World"})
+    refute_received({:goodbye, "World"})
+  end
+
+  test "subscribe with multi, but quoted pattern is not an array" do
+    result = Hub.subscribe("global", :not_a_list, multi: true)
+    assert result == {:error, "Must subscribe with a list of patterns when using multi: true"}
+  end
 end


### PR DESCRIPTION
Can subscribe to multiple patterns in one subscription

This is different than subscribing multiple times to different patterns, because of `count`.

E.g. 

```
subscribe("channel", [:foo, :bar], multi: true, count: 1)
publish("channel", :foo)
publish("channel", :bar)
```

Here, only `:foo` will be published to the subscriber, because `:foo` was published first.