### PR TITLE
Unsubscribe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.4.0 - 2017-12-18
+
+* Can unsubscribe ([#8](https://github.com/vesta-merkur/hub/pull/8))
+
+Breaking changes:
+
+* Hub.subscribe/3 and Hub.subscribe_quoted/3 now returns {:ok, reference} instead of :ok
+* Attempting to subscribe with the same pattern again from the same pid on the same channel will now make two
+  subscriptions. Before, the old one would be updated.
+
 ## 0.3.0 - 2017-11-22
 
 * Can subscribe to multiple patterns in one subscription ([#6](https://github.com/vesta-merkur/hub/pull/6))

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Add `hub` to your list of dependencies in `mix.exs`:
 
 ```elixir
 def deps do
-  [{:hub, "~> 0.3"}]
+  [{:hub, "~> 0.4"}]
 end
 ```
 
@@ -116,6 +116,15 @@ is equivalent to
 
 ```elixir
 Hub.subscribe("my channel", %{size: 42})
+```
+
+### Unsubscribe
+
+To unsubscribe, use the returned reference given when subscribing:
+
+```elixir
+{:ok, subscription} = Hub.subscribe("my cchannel", {:hello, name})
+Hub.unsubscribe(subscription)
 ```
 
 ## Examples

--- a/circle.yml
+++ b/circle.yml
@@ -19,9 +19,11 @@ dependencies:
     - MIX_ENV=test mix local.rebar --force
     - MIX_ENV=test mix deps.get
     - MIX_ENV=test mix deps.compile
-    - MIX_ENV=test mix dialyzer
+    - MIX_ENV=test mix dialyzer:
+      timeout: 1800
 test:
   override:
     - mix test
     - MIX_ENV=test mix credo
-    #- MIX_ENV=test mix dialyzer --halt-exit-status
+    - MIX_ENV=test mix dialyzer --halt-exit-status:
+      timeout: 1800

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Hub.Mixfile do
   def project do
     [
       app: :hub,
-      version: "0.3.0",
+      version: "0.4.0",
       elixir: "~> 1.4",
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,

--- a/test/hub_test.exs
+++ b/test/hub_test.exs
@@ -68,16 +68,16 @@ defmodule HubTest do
     assert_received({:hello, "World"})
   end
 
-  test "handle duplicate keys" do
+  test "can subscribe to same event multiple times" do
     pattern = quote do: {:hello, name}
     Hub.subscribe_quoted("global", pattern)
     Hub.subscribe_quoted("global", pattern)
     Hub.publish("global", {:hello, "World"})
 
     assert_received({:hello, "World"})
-    refute_received({:hello, "World"})
+    assert_received({:hello, "World"})
 
-    assert Hub.subscribers("global") |> length == 1
+    assert Hub.subscribers("global") |> length == 2
   end
 
   test "does not send to wrong channel" do

--- a/test/hub_test.exs
+++ b/test/hub_test.exs
@@ -178,4 +178,19 @@ defmodule HubTest do
     result = Hub.subscribe("global", :not_a_list, multi: true)
     assert result == {:error, "Must subscribe with a list of patterns when using multi: true"}
   end
+
+  test "subscribe, then unsubscribe" do
+    {:ok, ref} = Hub.subscribe("global", {:hello, name})
+    :ok = Hub.unsubscribe(ref)
+
+    Hub.publish("global", {:hello, "World"})
+
+    refute_received({:hello, "World"})
+    assert Hub.subscribers("global") == []
+  end
+
+  test "unsubscribe with unknown ref" do
+    invalid_ref = make_ref()
+    :ok = Hub.unsubscribe(invalid_ref)
+  end
 end


### PR DESCRIPTION
With this, it is possible to unsubscribe a subscription

* `Hub.subscribe` now returns a reference, which can be used in `Hub.unsubscribe`